### PR TITLE
Optionally use ureq instead of reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,12 @@ repository = "https://github.com/snakehand/tibber.git"
 
 [dependencies]
 serde = { version = "^1.0.78", features = ["derive"] }
-graphql_client = { version = "0.10.0" , features = ["reqwest-blocking"] }
-reqwest = { version = "^0.11", features = ["json", "blocking"] }
+reqwest = { version = "0.11", features = ["json", "blocking"], optional = true }
+graphql_client = { version = "0.14.0" }
 chrono = "0.4.19"
+ureq-crate = { package = "ureq", version = "2.10.1", features = ["json"], optional = true }
+
+[features]
+default = ["reqwest", "graphql_client/reqwest-blocking"]
+#default = ["ureq"]
+ureq = ["ureq-crate"]


### PR DESCRIPTION
This adds `ureq` as an optional HTTP client instead of `reqwest`.

On my machine, this means the number of dependencies goes from 148 to 109 for a release build, mostly because `ureq` isn't async and doesn't pull in any async runtime such as tokio. It also avoids pulling in openssl which makes static builds easier :).

Let me know if you agree it is a good idea (or if you wish to use only `ureq` instead of reqwest :) ).

Building this locally would be:

* `cargo build` (as before) to build the existing, reqwest-based version.
* `cargo build --no-default-features -F ureq` to build the ureq-based version.

Or, to use `tibber` as dependency with `ureq` enabled: `tibber = { version = "<the new version>", default-features = false, features = ["ureq"] }`