### PR TITLE
Derived PartialEq to PriceInfo and PriceLevel.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,7 @@ impl Features {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 /// Rough classification of price level compared to a 3 day moving avarage
 pub enum PriceLevel {
     /// Much lower than avarage
@@ -288,7 +288,7 @@ pub enum PriceLevel {
     None,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 /// Information about price in a particular interval
 pub struct PriceInfo {
     /// Total price


### PR DESCRIPTION
Reason: I need to filter the priceset vector for some specific price level. For toggling specific devices, I need to know whether there are prices of a specific level (cheap or very cheap) and how many of them. To use `.filter()` to the Priceset vector, it needs PartialEq on the vector and Pricelevel enum. So I added them.

If you merge that, I don't have to keep my program to rely to the fork ;)

Thanks