### PR TITLE
Fix typo in function name get_consu[m]ption()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -689,8 +689,20 @@ impl TibberSession {
         Ok(prices)
     }
 
-    /// Get historical consumption data for a particular house / home
+    /// Backward compatible typo version of [`Self::get_consumption()`],
+    /// deprecated.
+    #[deprecated]
     pub fn get_consuption(
+        &self,
+        home_id: &HomeId,
+        resolution: TimeResolution,
+        last: u32,
+    ) -> Result<Vec<Consumption>, Box<dyn std::error::Error>> {
+        self.get_consumption(home_id, resolution, last)
+    }
+
+    /// Get historical consumption data for a particular house / home
+    pub fn get_consumption(
         &self,
         home_id: &HomeId,
         resolution: TimeResolution,


### PR DESCRIPTION
I stumbled over a small typo in the getconsuption() function name and fixed it in my fork. Maybe you would like to merge it :)